### PR TITLE
pkgbuild.yml: get upstream versions prevent building the pkgbuild

### DIFF
--- a/.github/workflows/pkgbuild.yml
+++ b/.github/workflows/pkgbuild.yml
@@ -19,10 +19,6 @@ jobs:
     name: gather information
     runs-on: ubuntu-latest
     steps:
-      - name: get upstream versions
-        uses: manjaro-contrib/action-upstream-version@main
-        with:
-          name: lib32-mesa
       - name: check out repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - id: version


### PR DESCRIPTION
See: https://search.manjaro-sway.download/?name=lib32-mesa&branch=unstable&arch=x86_64
it's way behind upstream version