### PR TITLE
pkgbuild.yml: sync with the main mesa pkg

### DIFF
--- a/.github/workflows/pkgbuild.yml
+++ b/.github/workflows/pkgbuild.yml
@@ -12,17 +12,13 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   version:
     name: gather information
     runs-on: ubuntu-latest
     steps:
-      - name: get upstream versions
-        uses: manjaro-contrib/action-upstream-version@main
-        with:
-          name: lib32-mesa
       - name: check out repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - id: version


### PR DESCRIPTION
pkgbuild ci is skipping jobs over time until now.